### PR TITLE
Support ES module for Node.js (not full support)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .work/
 dist/
+src/_esm/
 **/*.d.ts

--- a/jest.config.basic.js
+++ b/jest.config.basic.js
@@ -4,7 +4,9 @@ module.exports = {
 	testEnvironment: 'node',
 	testMatch: ['<rootDir>/src/test/basic/**/*.ts'],
 	moduleNameMapper: {
+		'^@/(.*)\\.js$': '<rootDir>/src/main/$1',
 		'^@/(.*)$': '<rootDir>/src/main/$1',
+		'(.+)\\.js': '$1',
 	},
 	globals: {
 		'ts-jest': {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "main": "./dist/index.js",
   "module": "./dist/_esm/index.js",
   "exports": {
+    "node": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
     "import": "./dist/_esm/index.js",
     "require": "./dist/index.js"
   },
@@ -32,7 +36,7 @@
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "tsc -p ./tsconfig.app.json",
-    "build:esm": "tsc -p ./tsconfig.app.esm.json",
+    "build:esm": "tsc -p ./tsconfig.app.esm.json && node ./tools/copyEsmFile.js",
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "lint:eslint": "eslint -c .eslintrc.yml --ext .js,.jsx,.ts,.tsx .",
     "lint:eslint:fix": "eslint -c .eslintrc.yml --fix --ext .js,.jsx,.ts,.tsx .",

--- a/src/_esm/index.mjs
+++ b/src/_esm/index.mjs
@@ -1,0 +1,17 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+	NtExecutable,
+	NtExecutableResource,
+	calculateCheckSumForPE,
+	version,
+	Format,
+} = require('./index.js');
+export {
+	NtExecutable,
+	NtExecutableResource,
+	calculateCheckSumForPE,
+	version,
+	Format,
+};

--- a/src/main/NtExecutable.ts
+++ b/src/main/NtExecutable.ts
@@ -1,10 +1,10 @@
-import ImageDataDirectoryArray from './format/ImageDataDirectoryArray';
-import ImageDirectoryEntry from './format/ImageDirectoryEntry';
-import ImageDosHeader from './format/ImageDosHeader';
-import ImageNtHeaders from './format/ImageNtHeaders';
+import ImageDataDirectoryArray from './format/ImageDataDirectoryArray.js';
+import ImageDirectoryEntry from './format/ImageDirectoryEntry.js';
+import ImageDosHeader from './format/ImageDosHeader.js';
+import ImageNtHeaders from './format/ImageNtHeaders.js';
 import ImageSectionHeaderArray, {
 	ImageSectionHeader,
-} from './format/ImageSectionHeaderArray';
+} from './format/ImageSectionHeaderArray.js';
 
 import {
 	allocatePartialBinary,
@@ -12,8 +12,8 @@ import {
 	cloneObject,
 	cloneToArrayBuffer,
 	roundUp,
-} from './util/functions';
-import { makeEmptyNtExecutableBinary } from './util/generate';
+} from './util/functions.js';
+import { makeEmptyNtExecutableBinary } from './util/generate.js';
 
 export interface NtExecutableFromOptions {
 	/** true to parse binary even if the binary contains Certificate data (i.e. 'signed') */

--- a/src/main/NtExecutableResource.ts
+++ b/src/main/NtExecutableResource.ts
@@ -1,18 +1,18 @@
-import NtExecutable, { NtExecutableSection } from './NtExecutable';
-import ImageDirectoryEntry from './format/ImageDirectoryEntry';
-import { ImageSectionHeader } from './format/ImageSectionHeaderArray';
+import NtExecutable, { NtExecutableSection } from './NtExecutable.js';
+import ImageDirectoryEntry from './format/ImageDirectoryEntry.js';
+import { ImageSectionHeader } from './format/ImageSectionHeaderArray.js';
 import ResourceEntry, {
 	ResourceEntryBaseType,
 	ResourceEntryT,
 	ResourceEntryTT,
-} from './type/ResourceEntry';
+} from './type/ResourceEntry.js';
 import {
 	binaryToString,
 	cloneObject,
 	copyBuffer,
 	roundUp,
 	stringToBinary,
-} from './util/functions';
+} from './util/functions.js';
 
 function removeDuplicates<T>(a: readonly T[]): T[] {
 	return a.reduce<T[]>((p, c) => {

--- a/src/main/format/ArrayFormatBase.ts
+++ b/src/main/format/ArrayFormatBase.ts
@@ -1,4 +1,4 @@
-import FormatBase from './FormatBase';
+import FormatBase from './FormatBase.js';
 
 /** abstract class that support array-like methods and 'for...of' operation */
 abstract class ArrayFormatBase<T> extends FormatBase {

--- a/src/main/format/ImageDataDirectoryArray.ts
+++ b/src/main/format/ImageDataDirectoryArray.ts
@@ -1,4 +1,4 @@
-import ArrayFormatBase from './ArrayFormatBase';
+import ArrayFormatBase from './ArrayFormatBase.js';
 
 export interface ImageDataDirectory {
 	virtualAddress: number;

--- a/src/main/format/ImageDosHeader.ts
+++ b/src/main/format/ImageDosHeader.ts
@@ -1,5 +1,5 @@
-import FormatBase from './FormatBase';
-import { createDataView } from '../util/functions';
+import FormatBase from './FormatBase.js';
+import { createDataView } from '../util/functions.js';
 
 export default class ImageDosHeader extends FormatBase {
 	public static readonly size = 64;

--- a/src/main/format/ImageFileHeader.ts
+++ b/src/main/format/ImageFileHeader.ts
@@ -1,4 +1,4 @@
-import FormatBase from './FormatBase';
+import FormatBase from './FormatBase.js';
 
 export default class ImageFileHeader extends FormatBase {
 	public static readonly size = 20;

--- a/src/main/format/ImageNtHeaders.ts
+++ b/src/main/format/ImageNtHeaders.ts
@@ -1,9 +1,9 @@
-import FormatBase from './FormatBase';
-import ImageFileHeader from './ImageFileHeader';
-import ImageOptionalHeader from './ImageOptionalHeader';
-import ImageOptionalHeader64 from './ImageOptionalHeader64';
-import ImageDataDirectoryArray from './ImageDataDirectoryArray';
-import { createDataView } from '../util/functions';
+import FormatBase from './FormatBase.js';
+import ImageFileHeader from './ImageFileHeader.js';
+import ImageOptionalHeader from './ImageOptionalHeader.js';
+import ImageOptionalHeader64 from './ImageOptionalHeader64.js';
+import ImageDataDirectoryArray from './ImageDataDirectoryArray.js';
+import { createDataView } from '../util/functions.js';
 
 export default class ImageNtHeaders extends FormatBase {
 	public static readonly DEFAULT_SIGNATURE = 0x4550; // 'PE\x00\x00'

--- a/src/main/format/ImageOptionalHeader.ts
+++ b/src/main/format/ImageOptionalHeader.ts
@@ -1,4 +1,4 @@
-import FormatBase from './FormatBase';
+import FormatBase from './FormatBase.js';
 
 export default class ImageOptionalHeader extends FormatBase {
 	public static readonly size = 96;

--- a/src/main/format/ImageOptionalHeader64.ts
+++ b/src/main/format/ImageOptionalHeader64.ts
@@ -1,4 +1,4 @@
-import FormatBase from './FormatBase';
+import FormatBase from './FormatBase.js';
 
 function getUint64LE(view: DataView, offset: number) {
 	return (

--- a/src/main/format/ImageSectionHeaderArray.ts
+++ b/src/main/format/ImageSectionHeaderArray.ts
@@ -1,5 +1,5 @@
-import ArrayFormatBase from './ArrayFormatBase';
-import { getFixedString, setFixedString } from '../util/functions';
+import ArrayFormatBase from './ArrayFormatBase.js';
+import { getFixedString, setFixedString } from '../util/functions.js';
 
 export interface ImageSectionHeader {
 	name: string;

--- a/src/main/format/index.ts
+++ b/src/main/format/index.ts
@@ -1,17 +1,17 @@
-import ArrayFormatBase from './ArrayFormatBase';
-import FormatBase from './FormatBase';
+import ArrayFormatBase from './ArrayFormatBase.js';
+import FormatBase from './FormatBase.js';
 import ImageDataDirectoryArray, {
 	ImageDataDirectory,
-} from './ImageDataDirectoryArray';
-import ImageDirectoryEntry from './ImageDirectoryEntry';
-import ImageDosHeader from './ImageDosHeader';
-import ImageFileHeader from './ImageFileHeader';
-import ImageNtHeaders from './ImageNtHeaders';
-import ImageOptionalHeader from './ImageOptionalHeader';
-import ImageOptionalHeader64 from './ImageOptionalHeader64';
+} from './ImageDataDirectoryArray.js';
+import ImageDirectoryEntry from './ImageDirectoryEntry.js';
+import ImageDosHeader from './ImageDosHeader.js';
+import ImageFileHeader from './ImageFileHeader.js';
+import ImageNtHeaders from './ImageNtHeaders.js';
+import ImageOptionalHeader from './ImageOptionalHeader.js';
+import ImageOptionalHeader64 from './ImageOptionalHeader64.js';
 import ImageSectionHeaderArray, {
 	ImageSectionHeader,
-} from './ImageSectionHeaderArray';
+} from './ImageSectionHeaderArray.js';
 
 export {
 	ArrayFormatBase,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,13 +1,13 @@
 import NtExecutable, {
 	NtExecutableFromOptions,
 	NtExecutableSection,
-} from './NtExecutable';
-import NtExecutableResource from './NtExecutableResource';
-import { calculateCheckSumForPE } from './util/functions';
-import version from './version';
+} from './NtExecutable.js';
+import NtExecutableResource from './NtExecutableResource.js';
+import { calculateCheckSumForPE } from './util/functions.js';
+import version from './version.js';
 
-import * as Format from './format';
-import * as Type from './type';
+import * as Format from './format/index.js';
+import * as Type from './type/index.js';
 
 export {
 	NtExecutable,

--- a/src/main/type/index.ts
+++ b/src/main/type/index.ts
@@ -2,7 +2,7 @@ import ResourceEntry, {
 	ResourceEntryBaseType,
 	ResourceEntryT,
 	ResourceEntryTT,
-} from './ResourceEntry';
+} from './ResourceEntry.js';
 
 export {
 	ResourceEntry,

--- a/src/main/util/functions.ts
+++ b/src/main/util/functions.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference lib='dom' />
 
-import ImageDosHeader from '../format/ImageDosHeader';
+import ImageDosHeader from '../format/ImageDosHeader.js';
 
 // We must use 'object' for this function (Record<string, unknown> is not usable here)
 /* eslint-disable @typescript-eslint/ban-types */

--- a/src/main/util/generate.ts
+++ b/src/main/util/generate.ts
@@ -5,13 +5,13 @@
 //
 // NOTE: the original dos-stub.asm program and the bit code in DOS_STUB_PROGRAM are under the 0-BSD license.
 
-import ImageDataDirectoryArray from '../format/ImageDataDirectoryArray';
-import ImageDosHeader from '../format/ImageDosHeader';
-import ImageFileHeader from '../format/ImageFileHeader';
-import ImageNtHeaders from '../format/ImageNtHeaders';
-import ImageOptionalHeader from '../format/ImageOptionalHeader';
-import ImageOptionalHeader64 from '../format/ImageOptionalHeader64';
-import { copyBuffer, roundUp } from './functions';
+import ImageDataDirectoryArray from '../format/ImageDataDirectoryArray.js';
+import ImageDosHeader from '../format/ImageDosHeader.js';
+import ImageFileHeader from '../format/ImageFileHeader.js';
+import ImageNtHeaders from '../format/ImageNtHeaders.js';
+import ImageOptionalHeader from '../format/ImageOptionalHeader.js';
+import ImageOptionalHeader64 from '../format/ImageOptionalHeader64.js';
+import { copyBuffer, roundUp } from './functions.js';
 
 // fill with '0x00' to make 8-bytes alignment
 // prettier-ignore

--- a/src/test/basic/NtExecutable.ts
+++ b/src/test/basic/NtExecutable.ts
@@ -1,5 +1,5 @@
-import NtExecutable, { NtExecutableSection } from '@/NtExecutable';
-import ImageDirectoryEntry from '@/format/ImageDirectoryEntry';
+import NtExecutable, { NtExecutableSection } from '@/NtExecutable.js';
+import ImageDirectoryEntry from '@/format/ImageDirectoryEntry.js';
 
 // prettier-ignore
 const DUMMY_EXECUTABLE_32 = new Uint8Array([

--- a/src/test/basic/format/ArrayFormatBase.ts
+++ b/src/test/basic/format/ArrayFormatBase.ts
@@ -1,7 +1,7 @@
-import ArrayFormatBase from '@/format/ArrayFormatBase';
-import FormatBase from '@/format/FormatBase';
+import ArrayFormatBase from '@/format/ArrayFormatBase.js';
+import FormatBase from '@/format/FormatBase.js';
 
-jest.mock('@/format/FormatBase');
+jest.mock('@/format/FormatBase.js');
 
 interface DummyData {
 	id: string;

--- a/src/test/basic/format/FormatBase.ts
+++ b/src/test/basic/format/FormatBase.ts
@@ -1,4 +1,4 @@
-import FormatBase from '@/format/FormatBase';
+import FormatBase from '@/format/FormatBase.js';
 
 class DummyFormat extends FormatBase {
 	public constructor(view: DataView) {

--- a/src/test/basic/format/ImageDataDirectoryArray.ts
+++ b/src/test/basic/format/ImageDataDirectoryArray.ts
@@ -1,6 +1,6 @@
 import ImageDataDirectoryArray, {
 	ImageDataDirectory,
-} from '@/format/ImageDataDirectoryArray';
+} from '@/format/ImageDataDirectoryArray.js';
 
 // The definition:
 //

--- a/src/test/basic/format/ImageDosHeader.ts
+++ b/src/test/basic/format/ImageDosHeader.ts
@@ -1,5 +1,5 @@
-import ImageDosHeader from '@/format/ImageDosHeader';
-import { ExcludeNullField, getFieldOffset } from '../../testUtils/structure';
+import ImageDosHeader from '@/format/ImageDosHeader.js';
+import { ExcludeNullField, getFieldOffset } from '../../testUtils/structure.js';
 
 const FIELDS = [
 	['magic', 2],

--- a/src/test/basic/format/ImageFileHeader.ts
+++ b/src/test/basic/format/ImageFileHeader.ts
@@ -1,5 +1,5 @@
-import ImageFileHeader from '@/format/ImageFileHeader';
-import { getFieldOffset } from '../../testUtils/structure';
+import ImageFileHeader from '@/format/ImageFileHeader.js';
+import { getFieldOffset } from '../../testUtils/structure.js';
 
 // The definition:
 //

--- a/src/test/basic/format/ImageNtHeaders.ts
+++ b/src/test/basic/format/ImageNtHeaders.ts
@@ -1,10 +1,10 @@
-import ImageNtHeaders from '@/format/ImageNtHeaders';
-import { getFieldOffset } from '../../testUtils/structure';
+import ImageNtHeaders from '@/format/ImageNtHeaders.js';
+import { getFieldOffset } from '../../testUtils/structure.js';
 
-import ImageFileHeader from '@/format/ImageFileHeader';
-import ImageOptionalHeader from '@/format/ImageOptionalHeader';
-import ImageOptionalHeader64 from '@/format/ImageOptionalHeader64';
-import ImageDataDirectoryArray from '@/format/ImageDataDirectoryArray';
+import ImageFileHeader from '@/format/ImageFileHeader.js';
+import ImageOptionalHeader from '@/format/ImageOptionalHeader.js';
+import ImageOptionalHeader64 from '@/format/ImageOptionalHeader64.js';
+import ImageDataDirectoryArray from '@/format/ImageDataDirectoryArray.js';
 
 const FIELDS = [['signature', 4]] as const;
 

--- a/src/test/basic/format/ImageOptionalHeader.ts
+++ b/src/test/basic/format/ImageOptionalHeader.ts
@@ -1,5 +1,5 @@
-import ImageOptionalHeader from '@/format/ImageOptionalHeader';
-import { getFieldOffset } from '../../testUtils/structure';
+import ImageOptionalHeader from '@/format/ImageOptionalHeader.js';
+import { getFieldOffset } from '../../testUtils/structure.js';
 
 // The definition:
 //

--- a/src/test/basic/format/ImageOptionalHeader64.ts
+++ b/src/test/basic/format/ImageOptionalHeader64.ts
@@ -1,5 +1,5 @@
-import ImageOptionalHeader64 from '@/format/ImageOptionalHeader64';
-import { getFieldOffset } from '../../testUtils/structure';
+import ImageOptionalHeader64 from '@/format/ImageOptionalHeader64.js';
+import { getFieldOffset } from '../../testUtils/structure.js';
 
 // The definition:
 //

--- a/src/test/basic/format/ImageSectionHeaderArray.ts
+++ b/src/test/basic/format/ImageSectionHeaderArray.ts
@@ -1,7 +1,7 @@
 import ImageSectionHeaderArray, {
 	ImageSectionHeader,
-} from '@/format/ImageSectionHeaderArray';
-import { getFixedString, setFixedString } from '@/util/functions';
+} from '@/format/ImageSectionHeaderArray.js';
+import { getFixedString, setFixedString } from '@/util/functions.js';
 
 // The definition:
 //

--- a/src/test/basic/util/functions.ts
+++ b/src/test/basic/util/functions.ts
@@ -1,4 +1,4 @@
-import { copyBuffer, createDataView } from '@/util/functions';
+import { copyBuffer, createDataView } from '@/util/functions.js';
 
 function generateArrayBuffer(pattern: number[]) {
 	const bin = new ArrayBuffer(pattern.length);

--- a/tools/copyEsmFile.js
+++ b/tools/copyEsmFile.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+try {
+	fs.mkdirSync(path.join(ROOT_DIR, 'dist'));
+} catch {}
+
+fs.writeFileSync(
+	path.join(ROOT_DIR, 'dist/index.mjs'),
+	fs.readFileSync(path.join(ROOT_DIR, 'src/_esm/index.mjs'), 'utf8'),
+	'utf8'
+);


### PR DESCRIPTION
Related: jet2jet/resedit-js#34

This PR enables to load pe-library as a native ES module. To keep compatibility, `import`ing pe-library in Node.js environment will load CommonJS source code, so this PR is not full support for ES module.

(In the next major version release, I'll change API for CommonJS.)